### PR TITLE
Disable debug on default build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ MAN=
 BINDIR=	${PREFIX}/bin
 WARNS=	6
 
-CFLAGS=	-g
 LDADD=	-lpthread
 
 .include <bsd.prog.mk>


### PR DESCRIPTION
Default build shouldn't add debug symbols, it should be optional. On
FreeBSD ports tree for instance, if you pass -DWITH_DEBUG it's going to
make necessary changes like add -g and remove optimization from CFLAGS,
also disable strip from install command

Sponsored-by:   Rubicon Communications (Netgate)
