### PR TITLE
problem: cannot build on openbsd

### DIFF
--- a/dpinger.c
+++ b/dpinger.c
@@ -39,8 +39,8 @@
 #include <signal.h>
 
 #include <netdb.h>
-#include <net/if.h>
 #include <sys/socket.h>
+#include <net/if.h>
 #include <sys/un.h>
 #include <sys/stat.h>
 #include <netinet/in.h>


### PR DESCRIPTION
solution: include socket.h before if.h since if.h relies on types defined in socket.h

With this change I am able to build dpinger on openbsd using the `Makefile.freebsd`:

before:
```
$ make -f Makefile.freebsd
cc -O2 -pipe    -c dpinger.c
In file included from dpinger.c:42:
/usr/include/net/if.h:358: error: field 'ifru_addr' has incomplete type
/usr/include/net/if.h:359: error: field 'ifru_dstaddr' has incomplete type
/usr/include/net/if.h:360: error: field 'ifru_broadaddr' has incomplete type
/usr/include/net/if.h:387: error: field 'ifrau_addr' has incomplete type
/usr/include/net/if.h:393: error: field 'ifra_dstaddr' has incomplete type
/usr/include/net/if.h:395: error: field 'ifra_mask' has incomplete type
/usr/include/net/if.h:438: error: field 'addr' has incomplete type
/usr/include/net/if.h:439: error: field 'dstaddr' has incomplete type
In file included from /usr/include/net/if.h:454,
                 from dpinger.c:42:
/usr/include/net/if_arp.h:79: error: field 'arp_pa' has incomplete type
/usr/include/net/if_arp.h:80: error: field 'arp_ha' has incomplete type
*** Error 1 in /home/joeym/git/joemiller/dpinger (<sys.mk>:87 'dpinger.o')
```

after:
```
$ make -f Makefile.freebsd
cc -O2 -pipe    -c dpinger.c
cc   -o dpinger dpinger.o -lpthread
dpinger.o: In function `main':
dpinger.c:(.text+0xebf): warning: warning: strcpy() is almost always misused, please use strlcpy()

$ ./dpinger
Usage:
  ./dpinger [-f] [-R] [-S] [-P] [-B bind_addr] [-s send_interval] [-l loss_interval] [-t time_period] [-r report_interval] [-d data_length] [-o output_file] [-A alert_interval] [-D latency_alarm] [-L loss_alarm] [-C alert_cmd] [-i identif
ier] [-u usocket] [-p pidfile] dest_addr
```

Thanks for writing dpinger, btw! I've been using apinger for years and recently switched to dpinger.