### PR TITLE
Don't accept negative values. They are not valid.

### DIFF
--- a/dpinger.c
+++ b/dpinger.c
@@ -744,7 +744,7 @@ get_time_arg_msec(
     }
 
     // Garbage in the number?
-    if (*suffix != 0)
+    if (strchr(arg, '-') || *suffix != 0)
     {
         return 1;
     }
@@ -772,7 +772,7 @@ get_percent_arg(
     }
 
     // Garbage in the number?
-    if (*suffix != 0 || t > 100)
+    if (strchr(arg, '-') || *suffix != 0 || t > 100)
     {
         return 1;
     }
@@ -807,7 +807,7 @@ get_length_arg(
     }
 
     // Garbage in the number?
-    if (*suffix != 0)
+    if (strchr(arg, '-') || *suffix != 0)
     {
         return 1;
     }


### PR DESCRIPTION
Negative values produce erroneous results like this:

dpinger -f -B 192.168.1.48 -s -1 192.168.1.1
  the time period must be greater than twice the send interval plus the loss interval

dpinger -f -B 192.168.1.48 -s -1 -l 2000 -A 1 192.168.1.1
  send_interval 18446744073709551615ms	// 584 million years (2^64 - 1) (FFFFFFFFFFFFFFFF)
  loss_interval 2000ms
  time_period 60000ms
  report_interval 1000ms
  data_len 0
  alert_interval 1ms
  latency_alarm 0ms
  loss_alarm 0%
  dest_addr 192.168.1.1
  bind_addr 192.168.1.48
  identifier ""

Instead of clearer messages like this:

dpinger -f -B 192.168.1.48 -s -1 192.168.1.1
  invalid send interval -1

dpinger -f -B 192.168.1.48 -s -1 -l 2000 -A 1 192.168.1.1
  invalid send interval -1