### PR TITLE
redmine #8477

### DIFF
--- a/dpinger.c
+++ b/dpinger.c
@@ -855,7 +855,7 @@ get_length_arg(
 static void
 usage(void)
 {
-    fprintf(stderr, "Dpinger version 3.1.1\n\n");
+    fprintf(stderr, "Dpinger version 3.1\n\n");
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "  %s [-f] [-R] [-S] [-P] [-B bind_addr] [-s send_interval] [-l loss_interval] [-t time_period] [-r report_interval] [-d data_length] [-o output_file] [-A alert_interval] [-D latency_alarm] [-L loss_alarm] [-C alert_cmd] [-i identifier] [-u usocket] [-p pidfile] dest_addr\n\n", progname);
     fprintf(stderr, "  options:\n");

--- a/dpinger.c
+++ b/dpinger.c
@@ -313,6 +313,16 @@ ts_elapsed_usec(
 
 
 //
+// convert microseconds to milliseconds
+//
+static float
+usec_to_ms( int usec )
+{
+    return (float) usec / 1000;
+}
+
+
+//
 // Send thread
 //
 __attribute__ ((noreturn))
@@ -595,6 +605,8 @@ alert_thread(
     unsigned int                alert = 0;
     unsigned int                alarm_on;
     int                         r;
+    float                       average_latency_usec_in_ms = 0;
+    float                       latency_deviation_in_ms = 0;
 
     // Set up the timespec for nanosleep
     sleeptime.tv_sec = alert_interval_msec / 1000;
@@ -657,7 +669,10 @@ alert_thread(
             alert = 0;
 
             alarm_on = latency_alarm_decay || loss_alarm_decay;
-            logger("%s%s: %s latency %luus stddev %luus loss %lu%%\n", identifier, dest_str, alarm_on ? "Alarm" : "Clear", average_latency_usec, latency_deviation, average_loss_percent);
+            average_latency_usec_in_ms = usec_to_ms(average_latency_usec);
+            latency_deviation_in_ms = usec_to_ms(latency_deviation);
+
+            logger("%s%s: %s latency %.3fms stddev %.3fms loss %lu%%\n", identifier, dest_str, alarm_on ? "Alarm" : "Clear", average_latency_usec_in_ms, latency_deviation_in_ms, average_loss_percent);
 
             if (alert_cmd)
             {
@@ -840,7 +855,7 @@ get_length_arg(
 static void
 usage(void)
 {
-    fprintf(stderr, "Dpinger version 3.1\n\n");
+    fprintf(stderr, "Dpinger version 3.1.1\n\n");
     fprintf(stderr, "Usage:\n");
     fprintf(stderr, "  %s [-f] [-R] [-S] [-P] [-B bind_addr] [-s send_interval] [-l loss_interval] [-t time_period] [-r report_interval] [-d data_length] [-o output_file] [-A alert_interval] [-D latency_alarm] [-L loss_alarm] [-C alert_cmd] [-i identifier] [-u usocket] [-p pidfile] dest_addr\n\n", progname);
     fprintf(stderr, "  options:\n");


### PR DESCRIPTION
https://redmine.pfsense.org/issues/8477
- use ms for latency measurements in logs
- add small helper function `usec_to_ms()`
- bump version to 3.1.1